### PR TITLE
Enable stricter Travis CI with pipefail enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       os: osx
       sudo: required
       script:
-        - set -e
+        - set -eo pipefail
         - bash setup_dotfiles.sh
         - bash setup/setup_new_mac_machine.sh
         - sudo bash setup/_macos

--- a/setup/setup_new_mac_machine.sh
+++ b/setup/setup_new_mac_machine.sh
@@ -112,7 +112,9 @@ brew cask install avast-security  # Free Anti-virus protection
 # brew cask install spotify  # An amazing music streaming service
 brew cask install xquartz  # For running X server based apps
 brew cask install wireshark
-brew cask install zipeg  # A zip file reader
+# Try twice since this fails with the error message - "curl: (22) The requested URL returned error: 503 Service Unavailable"
+# Example https://travis-ci.org/ashishb/dotfiles/builds/543064482
+brew cask install zipeg || brew cask install zipeg # A zip file reader
 # TODO(ashishb): Add cask for Gyazo, an app for taking and uploading screenshots.
 
 # Battery health info. Not great but still good.


### PR DESCRIPTION
Enable stricter Travis CI with pipefail enabled. Also, try zipeg installation twice, since it seems to be flaky.