### PR TITLE
Fix broken travis CI testing on Linux

### DIFF
--- a/setup/setup_new_ubuntu_machine.sh
+++ b/setup/setup_new_ubuntu_machine.sh
@@ -9,7 +9,7 @@ sudo apt-get -y install git
 sudo apt-get -y install libxss1  # Required for Google-chrome.
 sudo apt-get -y install nmap
 # http://www.webupd8.org/2012/09/install-oracle-java-8-in-ubuntu-via-ppa.html
-yes | sudo apt-get install oracle-java8-installer  # Required for android.
+sudo apt-get -y install oracle-java8-installer  # Required for android.
 sudo apt-get -y install python-dev
 sudo apt-get -y install python-pip
 sudo apt-get -y install ssh
@@ -18,6 +18,7 @@ sudo apt-get -y install whois
 sudo apt-get -y install xsel
 sudo apt-get -y install zip  # I am surprised, how this can be missing.
 sudo apt-get -y remove thunderbird  # I don't need thunderbird.
+sudo pip install --upgrade pip
 # Use pip instead of easy_install.
 # http://stackoverflow.com/questions/3220404/why-use-pip-over-easy-install
 sudo pip install pylint
@@ -25,6 +26,10 @@ sudo pip install Pygments
 sudo pip install pdbpp  # A powerful improvement to pdb CLI.
 # Install Google chrome
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+if test "${CI}"; then
+    # https://askubuntu.com/questions/1065231/dpkg-deb-error-archive-has-premature-member-control-tar-xz-before-contr/1100361
+    sudo apt-get install dpkg
+fi
 sudo dpkg -i google-chrome-stable_current_amd64.deb
 
 #### Ubuntu specific settings. ####


### PR DESCRIPTION
 I tried moving from Trusty to Xenial and expected it should fix errors like
    https://travis-ci.org/ashishb/dotfiles/jobs/577997958

    Resolving dl.google.com (dl.google.com)... 108.177.111.190, 108.177.111.93, 108.177.111.136, ...
    Connecting to dl.google.com (dl.google.com)|108.177.111.190|:443... connected.
    HTTP request sent, awaiting response... 200 OK
    Length: 62302944 (59M) [application/x-debian-package]
    Saving to: ‘google-chrome-stable_current_amd64.deb’
    100%[======================================>] 62,302,944  67.2MB/s   in 0.9s
    2019-09-16 06:36:52 (67.2 MB/s) - ‘google-chrome-stable_current_amd64.deb’ saved [62302944/62302944]
    dpkg-deb: error: archive 'google-chrome-stable_current_amd64.deb' has premature member 'control.tar.xz' before 'control.tar.gz', giving up
    dpkg: error processing archive google-chrome-stable_current_amd64.deb (--install):
     subprocess dpkg-deb --control returned error exit status 2
    Errors were encountered while processing:
     google-chrome-stable_current_amd64.deb

    Such error is most likely a result of  .deb package being built with a
    newer version than the one dpkg can handle.

    And it did except it created problem with Java8 not being available.
    Since I don't want to resolve it now. I reverted to Trusty and fixed the
    dpkg being old.